### PR TITLE
Rename `runtime remaining` sensor to `time to empty`

### DIFF
--- a/components/ogt_bms_ble/ogt_bms_ble.cpp
+++ b/components/ogt_bms_ble/ogt_bms_ble.cpp
@@ -76,10 +76,10 @@ void OgtBmsBle::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t ga
       this->publish_state_(this->power_sensor_, NAN);
       this->publish_state_(this->charging_power_sensor_, NAN);
       this->publish_state_(this->discharging_power_sensor_, NAN);
-      this->publish_state_(this->runtime_remaining_sensor_, NAN);
-      this->publish_state_(this->runtime_remaining_text_sensor_, "");
+      this->publish_state_(this->time_to_empty_sensor_, NAN);
+      this->publish_state_(this->time_to_empty_formatted_text_sensor_, "");
       this->publish_state_(this->time_to_full_sensor_, NAN);
-      this->publish_state_(this->time_to_full_text_sensor_, "");
+      this->publish_state_(this->time_to_full_formatted_text_sensor_, "");
       this->publish_state_(this->charging_cycles_sensor_, NAN);
 
       this->publish_state_(this->min_cell_voltage_sensor_, NAN);
@@ -264,16 +264,16 @@ void OgtBmsBle::on_ogt_bms_ble_data(const std::vector<uint8_t> &encrypted_data) 
       }
       break;
     case OGT_COMMAND_TIME_TO_EMPTY:
-      this->publish_state_(this->runtime_remaining_sensor_, ogt_get_16bit(1) * 60.0f);
-      this->publish_state_(this->runtime_remaining_text_sensor_, format_runtime_remaining_(ogt_get_16bit(1) * 60.0f));
+      this->publish_state_(this->time_to_empty_sensor_, ogt_get_16bit(1) * 60.0f);
+      this->publish_state_(this->time_to_empty_formatted_text_sensor_, format_duration_(ogt_get_16bit(1) * 60.0f));
       break;
     case OGT_COMMAND_TIME_TO_FULL:
       if (ogt_get_16bit(1) == 0xFFFF) {
         this->publish_state_(this->time_to_full_sensor_, NAN);
-        this->publish_state_(this->time_to_full_text_sensor_, "");
+        this->publish_state_(this->time_to_full_formatted_text_sensor_, "");
       } else {
         this->publish_state_(this->time_to_full_sensor_, ogt_get_16bit(1) * 60.0f);
-        this->publish_state_(this->time_to_full_text_sensor_, format_runtime_remaining_(ogt_get_16bit(1) * 60.0f));
+        this->publish_state_(this->time_to_full_formatted_text_sensor_, format_duration_(ogt_get_16bit(1) * 60.0f));
       }
       break;
     case OGT_COMMAND_SERIAL_NUMBER:
@@ -317,7 +317,7 @@ void OgtBmsBle::dump_config() {  // NOLINT(google-readability-function-size,read
   LOG_SENSOR("", "Design capacity", this->design_capacity_sensor_);
   LOG_SENSOR("", "Full charge capacity", this->full_charge_capacity_sensor_);
   LOG_SENSOR("", "Mosfet temperature", this->mosfet_temperature_sensor_);
-  LOG_SENSOR("", "Runtime remaining", this->runtime_remaining_sensor_);
+  LOG_SENSOR("", "Time to empty", this->time_to_empty_sensor_);
   LOG_SENSOR("", "Time to full", this->time_to_full_sensor_);
 
   LOG_SENSOR("", "Error bitmask", this->error_bitmask_sensor_);
@@ -345,8 +345,8 @@ void OgtBmsBle::dump_config() {  // NOLINT(google-readability-function-size,read
   LOG_SENSOR("", "Cell Voltage 16", this->cells_[15].cell_voltage_sensor_);
 
   LOG_TEXT_SENSOR("", "Errors", this->errors_text_sensor_);
-  LOG_TEXT_SENSOR("", "Runtime remaining", this->runtime_remaining_text_sensor_);
-  LOG_TEXT_SENSOR("", "Time to full", this->time_to_full_text_sensor_);
+  LOG_TEXT_SENSOR("", "Time to empty", this->time_to_empty_formatted_text_sensor_);
+  LOG_TEXT_SENSOR("", "Time to full", this->time_to_full_formatted_text_sensor_);
 }
 
 void OgtBmsBle::publish_state_(binary_sensor::BinarySensor *binary_sensor, const bool &state) {

--- a/components/ogt_bms_ble/ogt_bms_ble.h
+++ b/components/ogt_bms_ble/ogt_bms_ble.h
@@ -50,9 +50,7 @@ class OgtBmsBle : public esphome::ble_client::BLEClientNode, public PollingCompo
   void set_mosfet_temperature_sensor(sensor::Sensor *mosfet_temperature_sensor) {
     mosfet_temperature_sensor_ = mosfet_temperature_sensor;
   }
-  void set_runtime_remaining_sensor(sensor::Sensor *runtime_remaining_sensor) {
-    runtime_remaining_sensor_ = runtime_remaining_sensor;
-  }
+  void set_time_to_empty_sensor(sensor::Sensor *time_to_empty_sensor) { time_to_empty_sensor_ = time_to_empty_sensor; }
   void set_time_to_full_sensor(sensor::Sensor *time_to_full_sensor) { time_to_full_sensor_ = time_to_full_sensor; }
   void set_capacity_remaining_sensor(sensor::Sensor *capacity_remaining_sensor) {
     capacity_remaining_sensor_ = capacity_remaining_sensor;
@@ -86,11 +84,11 @@ class OgtBmsBle : public esphome::ble_client::BLEClientNode, public PollingCompo
   }
 
   void set_errors_text_sensor(text_sensor::TextSensor *errors_text_sensor) { errors_text_sensor_ = errors_text_sensor; }
-  void set_runtime_remaining_text_sensor(text_sensor::TextSensor *runtime_remaining_text_sensor) {
-    runtime_remaining_text_sensor_ = runtime_remaining_text_sensor;
+  void set_time_to_empty_formatted_text_sensor(text_sensor::TextSensor *time_to_empty_formatted_text_sensor) {
+    time_to_empty_formatted_text_sensor_ = time_to_empty_formatted_text_sensor;
   }
-  void set_time_to_full_text_sensor(text_sensor::TextSensor *time_to_full_text_sensor) {
-    time_to_full_text_sensor_ = time_to_full_text_sensor;
+  void set_time_to_full_formatted_text_sensor(text_sensor::TextSensor *time_to_full_formatted_text_sensor) {
+    time_to_full_formatted_text_sensor_ = time_to_full_formatted_text_sensor;
   }
 
   void on_ogt_bms_ble_data(const std::vector<uint8_t> &encrypted_data);
@@ -111,7 +109,7 @@ class OgtBmsBle : public esphome::ble_client::BLEClientNode, public PollingCompo
   sensor::Sensor *state_of_charge_sensor_;
   sensor::Sensor *charging_cycles_sensor_;
   sensor::Sensor *mosfet_temperature_sensor_;
-  sensor::Sensor *runtime_remaining_sensor_;
+  sensor::Sensor *time_to_empty_sensor_;
   sensor::Sensor *time_to_full_sensor_;
   sensor::Sensor *average_cell_voltage_sensor_;
   sensor::Sensor *min_cell_voltage_sensor_;
@@ -125,8 +123,8 @@ class OgtBmsBle : public esphome::ble_client::BLEClientNode, public PollingCompo
   sensor::Sensor *full_charge_capacity_sensor_;
 
   text_sensor::TextSensor *errors_text_sensor_;
-  text_sensor::TextSensor *runtime_remaining_text_sensor_;
-  text_sensor::TextSensor *time_to_full_text_sensor_;
+  text_sensor::TextSensor *time_to_empty_formatted_text_sensor_;
+  text_sensor::TextSensor *time_to_full_formatted_text_sensor_;
 
   struct Cell {
     sensor::Sensor *cell_voltage_sensor_{nullptr};
@@ -147,7 +145,7 @@ class OgtBmsBle : public esphome::ble_client::BLEClientNode, public PollingCompo
 
   bool check_bit_(uint16_t mask, uint16_t flag) { return (mask & flag) == flag; }
 
-  std::string format_runtime_remaining_(const uint32_t value) {
+  std::string format_duration_(const uint32_t value) {
     int seconds = (int) value;
     int years = seconds / (24 * 3600 * 365);
     seconds = seconds % (24 * 3600 * 365);
@@ -155,7 +153,7 @@ class OgtBmsBle : public esphome::ble_client::BLEClientNode, public PollingCompo
     seconds = seconds % (24 * 3600);
     int hours = seconds / 3600;
     return (years ? to_string(years) + "y " : "") + (days ? to_string(days) + "d " : "") +
-           (hours ? to_string(hours) + "h" : "");
+           (hours ? to_string(hours) + "h " : "") + (minutes ? to_string(minutes) + "m " : "");
   }
 };
 

--- a/components/ogt_bms_ble/ogt_bms_ble.h
+++ b/components/ogt_bms_ble/ogt_bms_ble.h
@@ -152,6 +152,9 @@ class OgtBmsBle : public esphome::ble_client::BLEClientNode, public PollingCompo
     int days = seconds / (24 * 3600);
     seconds = seconds % (24 * 3600);
     int hours = seconds / 3600;
+    seconds = seconds % 3600;
+    int minutes = seconds / 60;
+    // seconds = seconds % 60;
     return (years ? to_string(years) + "y " : "") + (days ? to_string(days) + "d " : "") +
            (hours ? to_string(hours) + "h " : "") + (minutes ? to_string(minutes) + "m " : "");
   }

--- a/components/ogt_bms_ble/sensor.py
+++ b/components/ogt_bms_ble/sensor.py
@@ -48,7 +48,7 @@ CONF_MIN_VOLTAGE_CELL = "min_voltage_cell"
 CONF_MAX_VOLTAGE_CELL = "max_voltage_cell"
 CONF_DELTA_CELL_VOLTAGE = "delta_cell_voltage"
 CONF_AVERAGE_CELL_VOLTAGE = "average_cell_voltage"
-CONF_RUNTIME_REMAINING = "runtime_remaining"
+CONF_TIME_TO_EMPTY = "time_to_empty"
 CONF_TIME_TO_FULL = "time_to_full"
 
 CONF_CELL_VOLTAGE_1 = "cell_voltage_1"
@@ -112,7 +112,7 @@ SENSORS = [
     CONF_DESIGN_CAPACITY,
     CONF_FULL_CHARGE_CAPACITY,
     CONF_MOSFET_TEMPERATURE,
-    CONF_RUNTIME_REMAINING,
+    CONF_TIME_TO_EMPTY,
     CONF_TIME_TO_FULL,
     CONF_MIN_CELL_VOLTAGE,
     CONF_MAX_CELL_VOLTAGE,
@@ -188,7 +188,7 @@ CONFIG_SCHEMA = cv.Schema(
             device_class=DEVICE_CLASS_EMPTY,
             state_class=STATE_CLASS_MEASUREMENT,
         ),
-        cv.Optional(CONF_RUNTIME_REMAINING): sensor.sensor_schema(
+        cv.Optional(CONF_TIME_TO_EMPTY): sensor.sensor_schema(
             unit_of_measurement=UNIT_SECOND,
             icon="mdi:battery-remove-outline",
             accuracy_decimals=0,

--- a/components/ogt_bms_ble/text_sensor.py
+++ b/components/ogt_bms_ble/text_sensor.py
@@ -10,13 +10,13 @@ DEPENDENCIES = ["ogt_bms_ble"]
 CODEOWNERS = ["@syssi"]
 
 CONF_ERRORS = "errors"
-CONF_RUNTIME_REMAINING = "runtime_remaining"
-CONF_TIME_TO_FULL = "time_to_full"
+CONF_TIME_TO_EMPTY_FORMATTED = "time_to_empty_formatted"
+CONF_TIME_TO_FULL_FORMATTED = "time_to_full_formatted"
 
 TEXT_SENSORS = [
     CONF_ERRORS,
-    CONF_RUNTIME_REMAINING,
-    CONF_TIME_TO_FULL,
+    CONF_TIME_TO_EMPTY_FORMATTED,
+    CONF_TIME_TO_FULL_FORMATTED,
 ]
 
 CONFIG_SCHEMA = cv.Schema(
@@ -28,13 +28,15 @@ CONFIG_SCHEMA = cv.Schema(
                 cv.Optional(CONF_ICON, default="mdi:alert-circle-outline"): cv.icon,
             }
         ),
-        cv.Optional(CONF_RUNTIME_REMAINING): text_sensor.TEXT_SENSOR_SCHEMA.extend(
+        cv.Optional(
+            CONF_TIME_TO_EMPTY_FORMATTED
+        ): text_sensor.TEXT_SENSOR_SCHEMA.extend(
             {
                 cv.GenerateID(): cv.declare_id(text_sensor.TextSensor),
                 cv.Optional(CONF_ICON, default="mdi:battery-remove-outline"): cv.icon,
             }
         ),
-        cv.Optional(CONF_TIME_TO_FULL): text_sensor.TEXT_SENSOR_SCHEMA.extend(
+        cv.Optional(CONF_TIME_TO_FULL_FORMATTED): text_sensor.TEXT_SENSOR_SCHEMA.extend(
             {
                 cv.GenerateID(): cv.declare_id(text_sensor.TextSensor),
                 cv.Optional(CONF_ICON, default="mdi:battery-charging-100"): cv.icon,

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -97,8 +97,8 @@ sensor:
       name: "${name} full charge capacity"
     mosfet_temperature:
       name: "${name} mosfet temperature"
-    runtime_remaining:
-      name: "${name} runtime remaining"
+    time_to_empty:
+      name: "${name} time to empty"
     time_to_full:
       name: "${name} time to full"
 
@@ -151,10 +151,10 @@ sensor:
 text_sensor:
   - platform: ogt_bms_ble
     ogt_bms_ble_id: bms0
-    runtime_remaining:
-      name: "${name} runtime remaining"
-    time_to_full:
-      name: "${name} time to full"
+    time_to_empty_formatted:
+      name: "${name} time to empty formatted"
+    time_to_full_formatted:
+      name: "${name} time to full formatted"
 
 switch:
   - platform: ble_client

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -99,8 +99,8 @@ sensor:
       name: "${name} full charge capacity"
     mosfet_temperature:
       name: "${name} mosfet temperature"
-    runtime_remaining:
-      name: "${name} runtime remaining"
+    time_to_empty:
+      name: "${name} time to empty"
     time_to_full:
       name: "${name} time to full"
 
@@ -153,7 +153,7 @@ sensor:
 text_sensor:
   - platform: ogt_bms_ble
     ogt_bms_ble_id: bms0
-    runtime_remaining:
-      name: "${name} runtime remaining"
-    time_to_full:
-      name: "${name} time to full"
+    time_to_empty_formatted:
+      name: "${name} time to empty formatted"
+    time_to_full_formatted:
+      name: "${name} time to full formatted"


### PR DESCRIPTION
1. Rename `runtime remaining` to `time to empty`
2. Append the suffix `formatted` to the text sensors (`time to empty formatted`, `time to full formatted`)
3. Improve the resolution of the `format_duration` method (`4h` -> `4h 40m`). 