### PR TITLE
Use new_text_sensor() instead of deprecated register_text_sensor

### DIFF
--- a/components/ogt_bms_ble/text_sensor.py
+++ b/components/ogt_bms_ble/text_sensor.py
@@ -51,6 +51,5 @@ async def to_code(config):
     for key in TEXT_SENSORS:
         if key in config:
             conf = config[key]
-            sens = cg.new_Pvariable(conf[CONF_ID])
-            await text_sensor.register_text_sensor(sens, conf)
+            sens = await text_sensor.new_text_sensor(conf)
             cg.add(getattr(hub, f"set_{key}_text_sensor")(sens))

--- a/components/ogt_bms_ble/text_sensor.py
+++ b/components/ogt_bms_ble/text_sensor.py
@@ -1,7 +1,6 @@
 import esphome.codegen as cg
 from esphome.components import text_sensor
 import esphome.config_validation as cv
-from esphome.const import CONF_ID
 
 from . import OGT_BMS_BLE_COMPONENT_SCHEMA
 


### PR DESCRIPTION
## Summary
- Replace `cg.new_Pvariable(conf[CONF_ID])` + `await text_sensor.register_text_sensor(sens, conf)` with the modern `await text_sensor.new_text_sensor(conf)`
- Remove now-unused `CONF_ID` imports where applicable
- Aligns with the pattern already used in `sensor.py` via `await sensor.new_sensor(conf)`