### PR TITLE
Add entity_category to binary sensor and switch schemas

### DIFF
--- a/components/ogt_bms_ble/binary_sensor.py
+++ b/components/ogt_bms_ble/binary_sensor.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
-from esphome.const import CONF_ID
+from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC
 
 from . import OGT_BMS_BLE_COMPONENT_SCHEMA
 
@@ -20,10 +20,12 @@ BINARY_SENSORS = [
 CONFIG_SCHEMA = OGT_BMS_BLE_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_CHARGING): binary_sensor.binary_sensor_schema(
-            icon="mdi:battery-charging"
+            icon="mdi:battery-charging",
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_DISCHARGING): binary_sensor.binary_sensor_schema(
-            icon="mdi:power-plug"
+            icon="mdi:power-plug",
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
     }
 )
@@ -36,6 +38,5 @@ async def to_code(config):
     for key in BINARY_SENSORS:
         if key in config:
             conf = config[key]
-            sens = cg.new_Pvariable(conf[CONF_ID])
-            await binary_sensor.register_binary_sensor(sens, conf)
+            sens = await binary_sensor.new_binary_sensor(conf)
             cg.add(getattr(hub, f"set_{key}_binary_sensor")(sens))

--- a/components/ogt_bms_ble/button/__init__.py
+++ b/components/ogt_bms_ble/button/__init__.py
@@ -1,7 +1,6 @@
 import esphome.codegen as cg
 from esphome.components import button
 import esphome.config_validation as cv
-from esphome.const import CONF_ID
 
 from .. import CONF_OGT_BMS_BLE_ID, OGT_BMS_BLE_COMPONENT_SCHEMA, ogt_bms_ble_ns
 
@@ -36,8 +35,7 @@ async def to_code(config):
     for key, address in BUTTONS.items():
         if key in config:
             conf = config[key]
-            var = cg.new_Pvariable(conf[CONF_ID])
+            var = await button.new_button(conf)
             await cg.register_component(var, conf)
-            await button.register_button(var, conf)
             cg.add(var.set_parent(hub))
             cg.add(var.set_holding_register(address))


### PR DESCRIPTION
Add entity_category=ENTITY_CATEGORY_DIAGNOSTIC to all binary sensors (they report hardware state and protection events). Add entity_category=ENTITY_CATEGORY_CONFIG to configuration switches (bluetooth, buzzer, display). Primary functional switches (charging, discharging, balancer) remain uncategorized. This improves the Home Assistant entity list organization.