### PR TITLE
Initialize BLE char handle members to 0

### DIFF
--- a/components/ogt_bms_ble/ogt_bms_ble.h
+++ b/components/ogt_bms_ble/ogt_bms_ble.h
@@ -138,8 +138,8 @@ class OgtBmsBle : public esphome::ble_client::BLEClientNode, public PollingCompo
     sensor::Sensor *cell_voltage_sensor_{nullptr};
   } cells_[16];
 
-  uint16_t char_notify_handle_;
-  uint16_t char_command_handle_;
+  uint16_t char_notify_handle_{0};
+  uint16_t char_command_handle_{0};
   uint8_t next_command_{7};
   uint8_t encryption_key_;
   uint8_t device_type_;


### PR DESCRIPTION
## Summary

- `char_notify_handle_` and `char_command_handle_` were declared without initializers, leaving them with indeterminate values from construction until the first BLE connection.
- Adds `{0}` in-class member initializers to guarantee a defined state at construction.