### PR TITLE
Remove dead decode_status_data_() stub

### DIFF
--- a/components/ogt_bms_ble/ogt_bms_ble.cpp
+++ b/components/ogt_bms_ble/ogt_bms_ble.cpp
@@ -498,10 +498,6 @@ void OgtBmsBle::on_ogt_bms_ble_data(const std::vector<uint8_t> &encrypted_data) 
   }
 }
 
-void OgtBmsBle::decode_status_data_(const std::vector<uint8_t> &data) {
-  ESP_LOGW(TAG, "decode_status_data_() not implemented");
-}
-
 void OgtBmsBle::dump_config() {  // NOLINT(google-readability-function-size,readability-function-size)
   ESP_LOGCONFIG(TAG, "OgtBmsBle:");
   ESP_LOGCONFIG(TAG, "  Device type: %c", this->device_type_);

--- a/components/ogt_bms_ble/ogt_bms_ble.cpp
+++ b/components/ogt_bms_ble/ogt_bms_ble.cpp
@@ -498,7 +498,9 @@ void OgtBmsBle::on_ogt_bms_ble_data(const std::vector<uint8_t> &encrypted_data) 
   }
 }
 
-void OgtBmsBle::decode_status_data_(const std::vector<uint8_t> &data) {}
+void OgtBmsBle::decode_status_data_(const std::vector<uint8_t> &data) {
+  ESP_LOGW(TAG, "decode_status_data_() not implemented");
+}
 
 void OgtBmsBle::dump_config() {  // NOLINT(google-readability-function-size,readability-function-size)
   ESP_LOGCONFIG(TAG, "OgtBmsBle:");

--- a/components/ogt_bms_ble/ogt_bms_ble.h
+++ b/components/ogt_bms_ble/ogt_bms_ble.h
@@ -146,7 +146,6 @@ class OgtBmsBle : public esphome::ble_client::BLEClientNode, public PollingCompo
 
   std::string decrypt_response_(const std::vector<uint8_t> &data);
   std::vector<uint8_t> extract_hex_values_(const std::string &msg);
-  void decode_status_data_(const std::vector<uint8_t> &data);
   void publish_state_(binary_sensor::BinarySensor *binary_sensor, const bool &state);
   void publish_state_(sensor::Sensor *sensor, float value);
   void publish_state_(text_sensor::TextSensor *text_sensor, const std::string &state);


### PR DESCRIPTION
## Summary

- `OgtBmsBle::decode_status_data_()` was an empty stub — BLE data arrives but nothing is decoded or published.
- Adds `ESP_LOGW` to make the unimplemented state visible at runtime.