### PR TITLE
Add multiple devices example

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -421,7 +421,7 @@ jobs:
       - name: Validate example configurations
         run: |
           . venv/bin/activate
-          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password\nbms0_mac_address: FF:FF:FF:FF:FF:FF\nbms0_ble_name: SmartBat-A12345" > secrets.yaml
+          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password\nbms0_mac_address: FF:FF:FF:FF:FF:FF\nbms0_ble_name: SmartBat-A12345\nbms1_mac_address: EE:EE:EE:EE:EE:EE\nbms1_ble_name: SmartBat-A54321" > secrets.yaml
           for YAML in esp*.yaml; do
             esphome -s external_components_source components config $YAML
           done
@@ -429,7 +429,7 @@ jobs:
       - name: Validate test configurations
         run: |
           . venv/bin/activate
-          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password\nbms0_mac_address: FF:FF:FF:FF:FF:FF\nbms0_ble_name: SmartBat-A12345" > tests/secrets.yaml
+          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password\nbms0_mac_address: FF:FF:FF:FF:FF:FF\nbms0_ble_name: SmartBat-A12345\nbms1_mac_address: EE:EE:EE:EE:EE:EE\nbms1_ble_name: SmartBat-A54321" > tests/secrets.yaml
           for YAML in tests/esp*.yaml; do
             esphome -s external_components_source ../components config $YAML
           done
@@ -456,7 +456,7 @@ jobs:
       - name: Compile example configurations
         run: |
           . venv/bin/activate
-          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password\nbms0_mac_address: FF:FF:FF:FF:FF:FF\nbms0_ble_name: SmartBat-A12345" > secrets.yaml
+          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password\nbms0_mac_address: FF:FF:FF:FF:FF:FF\nbms0_ble_name: SmartBat-A12345\nbms1_mac_address: EE:EE:EE:EE:EE:EE\nbms1_ble_name: SmartBat-A54321" > secrets.yaml
           for YAML in esp*faker.yaml; do
             esphome -s external_components_source components compile $YAML
           done
@@ -464,5 +464,5 @@ jobs:
       - name: Compile test configurations
         run: |
           . venv/bin/activate
-          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password\nbms0_mac_address: FF:FF:FF:FF:FF:FF\nbms0_ble_name: SmartBat-A12345" > tests/secrets.yaml
+          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password\nbms0_mac_address: FF:FF:FF:FF:FF:FF\nbms0_ble_name: SmartBat-A12345\nbms1_mac_address: EE:EE:EE:EE:EE:EE\nbms1_ble_name: SmartBat-A54321" > tests/secrets.yaml
           esphome -s external_components_source ../components compile tests/esp32c6-compatibility-test.yaml

--- a/esp32-ble-example-multiple-devices.yaml
+++ b/esp32-ble-example-multiple-devices.yaml
@@ -1,0 +1,244 @@
+substitutions:
+  name: ogt-bms-ble
+  bms0: "${name} bms0"
+  bms1: "${name} bms1"
+  device_description: "Monitor a Offgridtec Battery Management System via BLE"
+  external_components_source: github://syssi/esphome-ogt-bms@main
+  bms0_mac_address: !secret bms0_mac_address
+  bms1_mac_address: !secret bms1_mac_address
+  bms0_ble_name: !secret bms0_ble_name
+  bms1_ble_name: !secret bms1_ble_name
+
+esphome:
+  name: ${name}
+  friendly_name: ${name}
+  comment: ${device_description}
+  project:
+    name: "syssi.esphome-ogt-bms"
+    version: 1.2.0
+  devices:
+    - id: device0
+      name: "${bms0}"
+    - id: device1
+      name: "${bms1}"
+
+esp32:
+  board: wemos_d1_mini32
+  framework:
+    type: esp-idf
+
+external_components:
+  - source: ${external_components_source}
+    refresh: 0s
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+
+ota:
+  platform: esphome
+  on_begin:
+    then:
+      - switch.turn_off: ble_client_switch0
+      - switch.turn_off: ble_client_switch1
+      - logger.log: "BLE connection suspended for OTA update"
+
+logger:
+  level: DEBUG
+
+# If you use Home Assistant please remove this `mqtt` section and uncomment the `api` component!
+# The native API has many advantages over MQTT: https://esphome.io/components/api.html#advantages-over-mqtt
+mqtt:
+  broker: !secret mqtt_host
+  username: !secret mqtt_username
+  password: !secret mqtt_password
+  id: mqtt_client
+
+# api:
+
+esp32_ble_tracker:
+  scan_parameters:
+    active: false
+
+ble_client:
+  - mac_address: ${bms0_mac_address}
+    id: client0
+  - mac_address: ${bms1_mac_address}
+    id: client1
+
+ogt_bms_ble:
+  - ble_client_id: client0
+    id: bms0
+    ble_name: ${bms0_ble_name}
+    update_interval: 10s
+  - ble_client_id: client1
+    id: bms1
+    ble_name: ${bms1_ble_name}
+    update_interval: 10s
+
+binary_sensor:
+  - platform: ogt_bms_ble
+    ogt_bms_ble_id: bms0
+    charging:
+      name: "${bms0} charging"
+      device_id: device0
+    discharging:
+      name: "${bms0} discharging"
+      device_id: device0
+
+  - platform: ogt_bms_ble
+    ogt_bms_ble_id: bms1
+    charging:
+      name: "${bms1} charging"
+      device_id: device1
+    discharging:
+      name: "${bms1} discharging"
+      device_id: device1
+
+button:
+  - platform: ogt_bms_ble
+    ogt_bms_ble_id: bms0
+    retrieve_serial_number:
+      name: "${bms0} retrieve serial number"
+      device_id: device0
+    retrieve_manufacture_date:
+      name: "${bms0} retrieve manufacture date"
+      device_id: device0
+
+  - platform: ogt_bms_ble
+    ogt_bms_ble_id: bms1
+    retrieve_serial_number:
+      name: "${bms1} retrieve serial number"
+      device_id: device1
+    retrieve_manufacture_date:
+      name: "${bms1} retrieve manufacture date"
+      device_id: device1
+
+sensor:
+  - platform: ogt_bms_ble
+    ogt_bms_ble_id: bms0
+    total_voltage:
+      name: "${bms0} total voltage"
+      device_id: device0
+    current:
+      name: "${bms0} current"
+      device_id: device0
+    power:
+      name: "${bms0} power"
+      device_id: device0
+    charging_power:
+      name: "${bms0} charging power"
+      device_id: device0
+    discharging_power:
+      name: "${bms0} discharging power"
+      device_id: device0
+    state_of_charge:
+      name: "${bms0} state of charge"
+      device_id: device0
+    charging_cycles:
+      name: "${bms0} charging cycles"
+      device_id: device0
+    capacity_remaining:
+      name: "${bms0} capacity remaining"
+      device_id: device0
+    design_capacity:
+      name: "${bms0} design capacity"
+      device_id: device0
+    full_charge_capacity:
+      name: "${bms0} full charge capacity"
+      device_id: device0
+    mosfet_temperature:
+      name: "${bms0} mosfet temperature"
+      device_id: device0
+    time_to_empty:
+      name: "${bms0} time to empty"
+      device_id: device0
+    time_to_full:
+      name: "${bms0} time to full"
+      device_id: device0
+
+  - platform: ogt_bms_ble
+    ogt_bms_ble_id: bms1
+    total_voltage:
+      name: "${bms1} total voltage"
+      device_id: device1
+    current:
+      name: "${bms1} current"
+      device_id: device1
+    power:
+      name: "${bms1} power"
+      device_id: device1
+    charging_power:
+      name: "${bms1} charging power"
+      device_id: device1
+    discharging_power:
+      name: "${bms1} discharging power"
+      device_id: device1
+    state_of_charge:
+      name: "${bms1} state of charge"
+      device_id: device1
+    charging_cycles:
+      name: "${bms1} charging cycles"
+      device_id: device1
+    capacity_remaining:
+      name: "${bms1} capacity remaining"
+      device_id: device1
+    design_capacity:
+      name: "${bms1} design capacity"
+      device_id: device1
+    full_charge_capacity:
+      name: "${bms1} full charge capacity"
+      device_id: device1
+    mosfet_temperature:
+      name: "${bms1} mosfet temperature"
+      device_id: device1
+    time_to_empty:
+      name: "${bms1} time to empty"
+      device_id: device1
+    time_to_full:
+      name: "${bms1} time to full"
+      device_id: device1
+
+switch:
+  - platform: ble_client
+    ble_client_id: client0
+    name: "${bms0} enable bluetooth connection"
+    id: ble_client_switch0
+    device_id: device0
+
+  - platform: ble_client
+    ble_client_id: client1
+    name: "${bms1} enable bluetooth connection"
+    id: ble_client_switch1
+    device_id: device1
+
+text_sensor:
+  - platform: ogt_bms_ble
+    ogt_bms_ble_id: bms0
+    time_to_empty_formatted:
+      name: "${bms0} time to empty formatted"
+      device_id: device0
+    time_to_full_formatted:
+      name: "${bms0} time to full formatted"
+      device_id: device0
+    serial_number:
+      name: "${bms0} serial number"
+      device_id: device0
+    manufacture_date:
+      name: "${bms0} manufacture date"
+      device_id: device0
+
+  - platform: ogt_bms_ble
+    ogt_bms_ble_id: bms1
+    time_to_empty_formatted:
+      name: "${bms1} time to empty formatted"
+      device_id: device1
+    time_to_full_formatted:
+      name: "${bms1} time to full formatted"
+      device_id: device1
+    serial_number:
+      name: "${bms1} serial number"
+      device_id: device1
+    manufacture_date:
+      name: "${bms1} manufacture date"
+      device_id: device1


### PR DESCRIPTION
ESPHome supports monitoring multiple BMS devices from a single ESP32 node using the `esphome.devices` block. This example demonstrates how to connect two BMS devices via BLE on one ESP32.