### PR TITLE
Remove redundant device name prefix from entity names

### DIFF
--- a/esp32-ble-example-multiple-devices.yaml
+++ b/esp32-ble-example-multiple-devices.yaml
@@ -80,135 +80,135 @@ binary_sensor:
   - platform: ogt_bms_ble
     ogt_bms_ble_id: bms0
     charging:
-      name: "${bms0} charging"
+      name: "charging"
       device_id: device0
     discharging:
-      name: "${bms0} discharging"
+      name: "discharging"
       device_id: device0
 
   - platform: ogt_bms_ble
     ogt_bms_ble_id: bms1
     charging:
-      name: "${bms1} charging"
+      name: "charging"
       device_id: device1
     discharging:
-      name: "${bms1} discharging"
+      name: "discharging"
       device_id: device1
 
 button:
   - platform: ogt_bms_ble
     ogt_bms_ble_id: bms0
     retrieve_serial_number:
-      name: "${bms0} retrieve serial number"
+      name: "retrieve serial number"
       device_id: device0
     retrieve_manufacture_date:
-      name: "${bms0} retrieve manufacture date"
+      name: "retrieve manufacture date"
       device_id: device0
 
   - platform: ogt_bms_ble
     ogt_bms_ble_id: bms1
     retrieve_serial_number:
-      name: "${bms1} retrieve serial number"
+      name: "retrieve serial number"
       device_id: device1
     retrieve_manufacture_date:
-      name: "${bms1} retrieve manufacture date"
+      name: "retrieve manufacture date"
       device_id: device1
 
 sensor:
   - platform: ogt_bms_ble
     ogt_bms_ble_id: bms0
     total_voltage:
-      name: "${bms0} total voltage"
+      name: "total voltage"
       device_id: device0
     current:
-      name: "${bms0} current"
+      name: "current"
       device_id: device0
     power:
-      name: "${bms0} power"
+      name: "power"
       device_id: device0
     charging_power:
-      name: "${bms0} charging power"
+      name: "charging power"
       device_id: device0
     discharging_power:
-      name: "${bms0} discharging power"
+      name: "discharging power"
       device_id: device0
     state_of_charge:
-      name: "${bms0} state of charge"
+      name: "state of charge"
       device_id: device0
     charging_cycles:
-      name: "${bms0} charging cycles"
+      name: "charging cycles"
       device_id: device0
     capacity_remaining:
-      name: "${bms0} capacity remaining"
+      name: "capacity remaining"
       device_id: device0
     design_capacity:
-      name: "${bms0} design capacity"
+      name: "design capacity"
       device_id: device0
     full_charge_capacity:
-      name: "${bms0} full charge capacity"
+      name: "full charge capacity"
       device_id: device0
     mosfet_temperature:
-      name: "${bms0} mosfet temperature"
+      name: "mosfet temperature"
       device_id: device0
     time_to_empty:
-      name: "${bms0} time to empty"
+      name: "time to empty"
       device_id: device0
     time_to_full:
-      name: "${bms0} time to full"
+      name: "time to full"
       device_id: device0
 
   - platform: ogt_bms_ble
     ogt_bms_ble_id: bms1
     total_voltage:
-      name: "${bms1} total voltage"
+      name: "total voltage"
       device_id: device1
     current:
-      name: "${bms1} current"
+      name: "current"
       device_id: device1
     power:
-      name: "${bms1} power"
+      name: "power"
       device_id: device1
     charging_power:
-      name: "${bms1} charging power"
+      name: "charging power"
       device_id: device1
     discharging_power:
-      name: "${bms1} discharging power"
+      name: "discharging power"
       device_id: device1
     state_of_charge:
-      name: "${bms1} state of charge"
+      name: "state of charge"
       device_id: device1
     charging_cycles:
-      name: "${bms1} charging cycles"
+      name: "charging cycles"
       device_id: device1
     capacity_remaining:
-      name: "${bms1} capacity remaining"
+      name: "capacity remaining"
       device_id: device1
     design_capacity:
-      name: "${bms1} design capacity"
+      name: "design capacity"
       device_id: device1
     full_charge_capacity:
-      name: "${bms1} full charge capacity"
+      name: "full charge capacity"
       device_id: device1
     mosfet_temperature:
-      name: "${bms1} mosfet temperature"
+      name: "mosfet temperature"
       device_id: device1
     time_to_empty:
-      name: "${bms1} time to empty"
+      name: "time to empty"
       device_id: device1
     time_to_full:
-      name: "${bms1} time to full"
+      name: "time to full"
       device_id: device1
 
 switch:
   - platform: ble_client
     ble_client_id: client0
-    name: "${bms0} enable bluetooth connection"
+    name: "enable bluetooth connection"
     id: ble_client_switch0
     device_id: device0
 
   - platform: ble_client
     ble_client_id: client1
-    name: "${bms1} enable bluetooth connection"
+    name: "enable bluetooth connection"
     id: ble_client_switch1
     device_id: device1
 
@@ -216,29 +216,29 @@ text_sensor:
   - platform: ogt_bms_ble
     ogt_bms_ble_id: bms0
     time_to_empty_formatted:
-      name: "${bms0} time to empty formatted"
+      name: "time to empty formatted"
       device_id: device0
     time_to_full_formatted:
-      name: "${bms0} time to full formatted"
+      name: "time to full formatted"
       device_id: device0
     serial_number:
-      name: "${bms0} serial number"
+      name: "serial number"
       device_id: device0
     manufacture_date:
-      name: "${bms0} manufacture date"
+      name: "manufacture date"
       device_id: device0
 
   - platform: ogt_bms_ble
     ogt_bms_ble_id: bms1
     time_to_empty_formatted:
-      name: "${bms1} time to empty formatted"
+      name: "time to empty formatted"
       device_id: device1
     time_to_full_formatted:
-      name: "${bms1} time to full formatted"
+      name: "time to full formatted"
       device_id: device1
     serial_number:
-      name: "${bms1} serial number"
+      name: "serial number"
       device_id: device1
     manufacture_date:
-      name: "${bms1} manufacture date"
+      name: "manufacture date"
       device_id: device1


### PR DESCRIPTION
Use ESPHome sub-devices feature: entity names no longer need the device name prefix since the sub-device name is automatically prepended by Home Assistant via `has_entity_name = True` semantics.

- Remove `${bms0}`/`${bms1}` prefix from all entity `name:` fields in `*multiple-devices*.yaml`
- Add `devices:` block and `device_id:` per entity where missing (jbd-bms, tianpower-bms)
- Add `device_id:` to `ble_client` switches where missing (lolan-bms, jk-bms)