### PR TITLE
Refactor sensor and binary_sensor schema definitions

### DIFF
--- a/components/ogt_bms_ble/binary_sensor.py
+++ b/components/ogt_bms_ble/binary_sensor.py
@@ -12,21 +12,24 @@ CODEOWNERS = ["@syssi"]
 CONF_CHARGING = "charging"
 CONF_DISCHARGING = "discharging"
 
-BINARY_SENSORS = [
-    CONF_CHARGING,
-    CONF_DISCHARGING,
-]
+# key: binary_sensor_schema kwargs
+BINARY_SENSOR_DEFS = {
+    CONF_CHARGING: {
+        "icon": "mdi:battery-charging",
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_DISCHARGING: {
+        "icon": "mdi:power-plug",
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+}
+
+BINARY_SENSORS = list(BINARY_SENSOR_DEFS)
 
 CONFIG_SCHEMA = OGT_BMS_BLE_COMPONENT_SCHEMA.extend(
     {
-        cv.Optional(CONF_CHARGING): binary_sensor.binary_sensor_schema(
-            icon="mdi:battery-charging",
-            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-        ),
-        cv.Optional(CONF_DISCHARGING): binary_sensor.binary_sensor_schema(
-            icon="mdi:power-plug",
-            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-        ),
+        cv.Optional(key): binary_sensor.binary_sensor_schema(**kwargs)
+        for key, kwargs in BINARY_SENSOR_DEFS.items()
     }
 )
 

--- a/components/ogt_bms_ble/sensor.py
+++ b/components/ogt_bms_ble/sensor.py
@@ -52,23 +52,6 @@ CONF_AVERAGE_CELL_VOLTAGE = "average_cell_voltage"
 CONF_TIME_TO_EMPTY = "time_to_empty"
 CONF_TIME_TO_FULL = "time_to_full"
 
-CONF_CELL_VOLTAGE_1 = "cell_voltage_1"
-CONF_CELL_VOLTAGE_2 = "cell_voltage_2"
-CONF_CELL_VOLTAGE_3 = "cell_voltage_3"
-CONF_CELL_VOLTAGE_4 = "cell_voltage_4"
-CONF_CELL_VOLTAGE_5 = "cell_voltage_5"
-CONF_CELL_VOLTAGE_6 = "cell_voltage_6"
-CONF_CELL_VOLTAGE_7 = "cell_voltage_7"
-CONF_CELL_VOLTAGE_8 = "cell_voltage_8"
-CONF_CELL_VOLTAGE_9 = "cell_voltage_9"
-CONF_CELL_VOLTAGE_10 = "cell_voltage_10"
-CONF_CELL_VOLTAGE_11 = "cell_voltage_11"
-CONF_CELL_VOLTAGE_12 = "cell_voltage_12"
-CONF_CELL_VOLTAGE_13 = "cell_voltage_13"
-CONF_CELL_VOLTAGE_14 = "cell_voltage_14"
-CONF_CELL_VOLTAGE_15 = "cell_voltage_15"
-CONF_CELL_VOLTAGE_16 = "cell_voltage_16"
-
 ICON_CURRENT_DC = "mdi:current-dc"
 ICON_CHARGING_CYCLES = "mdi:battery-sync"
 ICON_ERROR_BITMASK = "mdi:alert-circle-outline"
@@ -81,301 +64,167 @@ ICON_MAX_VOLTAGE_CELL = "mdi:battery-plus-outline"
 
 UNIT_AMPERE_HOURS = "Ah"
 
-CELLS = [
-    CONF_CELL_VOLTAGE_1,
-    CONF_CELL_VOLTAGE_2,
-    CONF_CELL_VOLTAGE_3,
-    CONF_CELL_VOLTAGE_4,
-    CONF_CELL_VOLTAGE_5,
-    CONF_CELL_VOLTAGE_6,
-    CONF_CELL_VOLTAGE_7,
-    CONF_CELL_VOLTAGE_8,
-    CONF_CELL_VOLTAGE_9,
-    CONF_CELL_VOLTAGE_10,
-    CONF_CELL_VOLTAGE_11,
-    CONF_CELL_VOLTAGE_12,
-    CONF_CELL_VOLTAGE_13,
-    CONF_CELL_VOLTAGE_14,
-    CONF_CELL_VOLTAGE_15,
-    CONF_CELL_VOLTAGE_16,
-]
+CELLS = [f"cell_voltage_{i}" for i in range(1, 17)]
 
-SENSORS = [
-    CONF_TOTAL_VOLTAGE,
-    CONF_CURRENT,
-    CONF_POWER,
-    CONF_CHARGING_POWER,
-    CONF_DISCHARGING_POWER,
-    CONF_ERROR_BITMASK,
-    CONF_STATE_OF_CHARGE,
-    CONF_CHARGING_CYCLES,
-    CONF_CAPACITY_REMAINING,
-    CONF_DESIGN_CAPACITY,
-    CONF_FULL_CHARGE_CAPACITY,
-    CONF_MOSFET_TEMPERATURE,
-    CONF_TIME_TO_EMPTY,
-    CONF_TIME_TO_FULL,
-    CONF_MIN_CELL_VOLTAGE,
-    CONF_MAX_CELL_VOLTAGE,
-    CONF_MIN_VOLTAGE_CELL,
-    CONF_MAX_VOLTAGE_CELL,
-    CONF_DELTA_CELL_VOLTAGE,
-    CONF_AVERAGE_CELL_VOLTAGE,
-]
+# key: sensor_schema kwargs
+SENSOR_DEFS = {
+    CONF_TOTAL_VOLTAGE: {
+        "unit_of_measurement": UNIT_VOLT,
+        "icon": ICON_EMPTY,
+        "accuracy_decimals": 3,
+        "device_class": DEVICE_CLASS_VOLTAGE,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_CURRENT: {
+        "unit_of_measurement": UNIT_AMPERE,
+        "icon": ICON_CURRENT_DC,
+        "accuracy_decimals": 2,
+        "device_class": DEVICE_CLASS_CURRENT,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_POWER: {
+        "unit_of_measurement": UNIT_WATT,
+        "icon": ICON_EMPTY,
+        "accuracy_decimals": 2,
+        "device_class": DEVICE_CLASS_POWER,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_CHARGING_POWER: {
+        "unit_of_measurement": UNIT_WATT,
+        "icon": ICON_EMPTY,
+        "accuracy_decimals": 2,
+        "device_class": DEVICE_CLASS_POWER,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_DISCHARGING_POWER: {
+        "unit_of_measurement": UNIT_WATT,
+        "icon": ICON_EMPTY,
+        "accuracy_decimals": 2,
+        "device_class": DEVICE_CLASS_POWER,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_ERROR_BITMASK: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": ICON_ERROR_BITMASK,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_STATE_OF_CHARGE: {
+        "unit_of_measurement": UNIT_PERCENT,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_BATTERY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_CHARGING_CYCLES: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": ICON_CHARGING_CYCLES,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_TOTAL_INCREASING,
+    },
+    CONF_TIME_TO_FULL: {
+        "unit_of_measurement": UNIT_SECOND,
+        "icon": "mdi:battery-charging-100",
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_TIME_TO_EMPTY: {
+        "unit_of_measurement": UNIT_SECOND,
+        "icon": "mdi:battery-remove-outline",
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_MIN_CELL_VOLTAGE: {
+        "unit_of_measurement": UNIT_VOLT,
+        "icon": ICON_MIN_CELL_VOLTAGE,
+        "accuracy_decimals": 3,
+        "device_class": DEVICE_CLASS_VOLTAGE,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_MAX_CELL_VOLTAGE: {
+        "unit_of_measurement": UNIT_VOLT,
+        "icon": ICON_MAX_CELL_VOLTAGE,
+        "accuracy_decimals": 3,
+        "device_class": DEVICE_CLASS_VOLTAGE,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_MIN_VOLTAGE_CELL: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": ICON_MIN_VOLTAGE_CELL,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_MAX_VOLTAGE_CELL: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": ICON_MAX_VOLTAGE_CELL,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_DELTA_CELL_VOLTAGE: {
+        "unit_of_measurement": UNIT_VOLT,
+        "icon": ICON_EMPTY,
+        "accuracy_decimals": 3,
+        "device_class": DEVICE_CLASS_VOLTAGE,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_AVERAGE_CELL_VOLTAGE: {
+        "unit_of_measurement": UNIT_VOLT,
+        "icon": ICON_EMPTY,
+        "accuracy_decimals": 4,
+        "device_class": DEVICE_CLASS_VOLTAGE,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_MOSFET_TEMPERATURE: {
+        "unit_of_measurement": UNIT_CELSIUS,
+        "accuracy_decimals": 2,
+        "device_class": DEVICE_CLASS_TEMPERATURE,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_CAPACITY_REMAINING: {
+        "unit_of_measurement": UNIT_AMPERE_HOURS,
+        "icon": ICON_CAPACITY_REMAINING,
+        "accuracy_decimals": 3,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_DESIGN_CAPACITY: {
+        "unit_of_measurement": UNIT_AMPERE_HOURS,
+        "icon": ICON_CAPACITY_REMAINING,
+        "accuracy_decimals": 3,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_FULL_CHARGE_CAPACITY: {
+        "unit_of_measurement": UNIT_AMPERE_HOURS,
+        "icon": ICON_CAPACITY_REMAINING,
+        "accuracy_decimals": 3,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+}
 
-# pylint: disable=too-many-function-args
+SENSORS = list(SENSOR_DEFS)
+
+_CELL_VOLTAGE_SCHEMA = sensor.sensor_schema(
+    unit_of_measurement=UNIT_VOLT,
+    icon=ICON_EMPTY,
+    accuracy_decimals=3,
+    device_class=DEVICE_CLASS_VOLTAGE,
+    state_class=STATE_CLASS_MEASUREMENT,
+)
+
 CONFIG_SCHEMA = OGT_BMS_BLE_COMPONENT_SCHEMA.extend(
     {
-        cv.Optional(CONF_TOTAL_VOLTAGE): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CURRENT): sensor.sensor_schema(
-            unit_of_measurement=UNIT_AMPERE,
-            icon=ICON_CURRENT_DC,
-            accuracy_decimals=2,
-            device_class=DEVICE_CLASS_CURRENT,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_POWER): sensor.sensor_schema(
-            unit_of_measurement=UNIT_WATT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=2,
-            device_class=DEVICE_CLASS_POWER,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CHARGING_POWER): sensor.sensor_schema(
-            unit_of_measurement=UNIT_WATT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=2,
-            device_class=DEVICE_CLASS_POWER,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_DISCHARGING_POWER): sensor.sensor_schema(
-            unit_of_measurement=UNIT_WATT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=2,
-            device_class=DEVICE_CLASS_POWER,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_ERROR_BITMASK): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon=ICON_ERROR_BITMASK,
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-        ),
-        cv.Optional(CONF_STATE_OF_CHARGE): sensor.sensor_schema(
-            unit_of_measurement=UNIT_PERCENT,
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_BATTERY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CHARGING_CYCLES): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon=ICON_CHARGING_CYCLES,
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_TOTAL_INCREASING,
-        ),
-        cv.Optional(CONF_TIME_TO_FULL): sensor.sensor_schema(
-            unit_of_measurement=UNIT_SECOND,
-            icon="mdi:battery-charging-100",
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_TIME_TO_EMPTY): sensor.sensor_schema(
-            unit_of_measurement=UNIT_SECOND,
-            icon="mdi:battery-remove-outline",
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_MIN_CELL_VOLTAGE): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_MIN_CELL_VOLTAGE,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_MAX_CELL_VOLTAGE): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_MAX_CELL_VOLTAGE,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_MIN_VOLTAGE_CELL): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon=ICON_MIN_VOLTAGE_CELL,
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_MAX_VOLTAGE_CELL): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon=ICON_MAX_VOLTAGE_CELL,
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_DELTA_CELL_VOLTAGE): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_AVERAGE_CELL_VOLTAGE): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=4,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_MOSFET_TEMPERATURE): sensor.sensor_schema(
-            unit_of_measurement=UNIT_CELSIUS,
-            accuracy_decimals=2,
-            device_class=DEVICE_CLASS_TEMPERATURE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_1): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_2): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_3): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_4): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_5): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_6): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_7): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_8): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_9): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_10): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_11): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_12): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_13): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_14): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_15): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_16): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CAPACITY_REMAINING): sensor.sensor_schema(
-            unit_of_measurement=UNIT_AMPERE_HOURS,
-            icon=ICON_CAPACITY_REMAINING,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_DESIGN_CAPACITY): sensor.sensor_schema(
-            unit_of_measurement=UNIT_AMPERE_HOURS,
-            icon=ICON_CAPACITY_REMAINING,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_FULL_CHARGE_CAPACITY): sensor.sensor_schema(
-            unit_of_measurement=UNIT_AMPERE_HOURS,
-            icon=ICON_CAPACITY_REMAINING,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
+        **{
+            cv.Optional(key): sensor.sensor_schema(**kwargs)
+            for key, kwargs in SENSOR_DEFS.items()
+        },
+        **{cv.Optional(key): _CELL_VOLTAGE_SCHEMA for key in CELLS},
     }
 )
 


### PR DESCRIPTION
Replace flat `SENSORS`/`BINARY_SENSORS` lists and verbose per-entry `CONFIG_SCHEMA` blocks with `SENSOR_DEFS`/`BINARY_SENSOR_DEFS` dicts. `CONFIG_SCHEMA` is now built from a single dict comprehension, making it trivial to add new entities with full kwargs support.

Also replaces individual `CONF_CELL_VOLTAGE_N` / `CONF_TEMPERATURE_N` constants with f-string comprehensions (`CELLS`, `TEMPERATURES`), and introduces shared `_CELL_VOLTAGE_SCHEMA` / `_TEMPERATURE_SCHEMA` variables where applicable.