### PR TITLE
Iterate over BINARY_SENSOR_DEFS/SENSOR_DEFS directly in to_code

### DIFF
--- a/components/ogt_bms_ble/binary_sensor.py
+++ b/components/ogt_bms_ble/binary_sensor.py
@@ -24,8 +24,6 @@ BINARY_SENSOR_DEFS = {
     },
 }
 
-BINARY_SENSORS = list(BINARY_SENSOR_DEFS)
-
 CONFIG_SCHEMA = OGT_BMS_BLE_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(key): binary_sensor.binary_sensor_schema(**kwargs)
@@ -38,7 +36,7 @@ async def to_code(config):
     from . import CONF_OGT_BMS_BLE_ID
 
     hub = await cg.get_variable(config[CONF_OGT_BMS_BLE_ID])
-    for key in BINARY_SENSORS:
+    for key in BINARY_SENSOR_DEFS:
         if key in config:
             conf = config[key]
             sens = await binary_sensor.new_binary_sensor(conf)

--- a/components/ogt_bms_ble/sensor.py
+++ b/components/ogt_bms_ble/sensor.py
@@ -208,8 +208,6 @@ SENSOR_DEFS = {
     },
 }
 
-SENSORS = list(SENSOR_DEFS)
-
 _CELL_VOLTAGE_SCHEMA = sensor.sensor_schema(
     unit_of_measurement=UNIT_VOLT,
     icon=ICON_EMPTY,
@@ -238,7 +236,7 @@ async def to_code(config):
             conf = config[key]
             sens = await sensor.new_sensor(conf)
             cg.add(hub.set_cell_voltage_sensor(i, sens))
-    for key in SENSORS:
+    for key in SENSOR_DEFS:
         if key in config:
             conf = config[key]
             sens = await sensor.new_sensor(conf)


### PR DESCRIPTION
## Summary

- Remove redundant `BINARY_SENSORS = list(BINARY_SENSOR_DEFS)` and `SENSORS = list(SENSOR_DEFS)` aliases
- Iterate over `BINARY_SENSOR_DEFS` / `SENSOR_DEFS` directly in `to_code` instead