### PR TITLE
Use C++17 concatenated namespace syntax

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -96,7 +96,6 @@ Checks: >-
   -modernize-avoid-variadic-functions,
   -modernize-avoid-c-arrays,
   -modernize-avoid-c-style-cast,
-  -modernize-concat-nested-namespaces,
   -modernize-macro-to-enum,
   -modernize-return-braced-init-list,
   -modernize-type-traits,

--- a/components/ogt_bms_ble/button/ogt_button.cpp
+++ b/components/ogt_bms_ble/button/ogt_button.cpp
@@ -2,13 +2,11 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace ogt_bms_ble {
+namespace esphome::ogt_bms_ble {
 
 static const char *const TAG = "ogt_bms_ble.button";
 
 void OgtButton::dump_config() { LOG_BUTTON("", "OgtBmsBle Button", this); }
 void OgtButton::press_action() { this->parent_->send_command(this->holding_register_, 2); }
 
-}  // namespace ogt_bms_ble
-}  // namespace esphome
+}  // namespace esphome::ogt_bms_ble

--- a/components/ogt_bms_ble/button/ogt_button.h
+++ b/components/ogt_bms_ble/button/ogt_button.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/button/button.h"
 
-namespace esphome {
-namespace ogt_bms_ble {
+namespace esphome::ogt_bms_ble {
 
 class OgtBmsBle;
 class OgtButton : public button::Button, public Component {
@@ -22,5 +21,4 @@ class OgtButton : public button::Button, public Component {
   uint8_t holding_register_;
 };
 
-}  // namespace ogt_bms_ble
-}  // namespace esphome
+}  // namespace esphome::ogt_bms_ble

--- a/components/ogt_bms_ble/ogt_bms_ble.cpp
+++ b/components/ogt_bms_ble/ogt_bms_ble.cpp
@@ -9,8 +9,7 @@
 #define ADDR_STR(x) (x).c_str()
 #endif
 
-namespace esphome {
-namespace ogt_bms_ble {
+namespace esphome::ogt_bms_ble {
 
 static const char *const TAG = "ogt_bms_ble";
 
@@ -653,5 +652,4 @@ void OgtBmsBle::update_cell_voltage_stats_() {
   }
 }
 
-}  // namespace ogt_bms_ble
-}  // namespace esphome
+}  // namespace esphome::ogt_bms_ble

--- a/components/ogt_bms_ble/ogt_bms_ble.h
+++ b/components/ogt_bms_ble/ogt_bms_ble.h
@@ -12,8 +12,7 @@
 namespace espbt = esphome::esp32_ble_tracker;
 #endif
 
-namespace esphome {
-namespace ogt_bms_ble {
+namespace esphome::ogt_bms_ble {
 
 class OgtBmsBle :
 #ifdef USE_ESP32
@@ -184,5 +183,4 @@ class OgtBmsBle :
   }
 };
 
-}  // namespace ogt_bms_ble
-}  // namespace esphome
+}  // namespace esphome::ogt_bms_ble


### PR DESCRIPTION
The `modernize-concat-nested-namespaces` check is active in ESPHome's CI. All nested namespace blocks are replaced with `namespace esphome::X` syntax. The `.clang-tidy` is synced to the current ESPHome dev version.