### PR TITLE
Move BLE MAC address to secrets.yaml

### DIFF
--- a/esp32-ble-example-multiple-devices.yaml
+++ b/esp32-ble-example-multiple-devices.yaml
@@ -4,8 +4,6 @@ substitutions:
   bms1: "${name} bms1"
   device_description: "Monitor a Offgridtec Battery Management System via BLE"
   external_components_source: github://syssi/esphome-ogt-bms@main
-  bms0_mac_address: !secret bms0_mac_address
-  bms1_mac_address: !secret bms1_mac_address
   bms0_ble_name: !secret bms0_ble_name
   bms1_ble_name: !secret bms1_ble_name
 
@@ -62,9 +60,9 @@ esp32_ble_tracker:
     active: false
 
 ble_client:
-  - mac_address: ${bms0_mac_address}
+  - mac_address: !secret bms0_mac_address
     id: client0
-  - mac_address: ${bms1_mac_address}
+  - mac_address: !secret bms1_mac_address
     id: client1
 
 ogt_bms_ble:

--- a/esp32-ble-example-multiple-devices.yaml
+++ b/esp32-ble-example-multiple-devices.yaml
@@ -4,8 +4,6 @@ substitutions:
   bms1: "${name} bms1"
   device_description: "Monitor a Offgridtec Battery Management System via BLE"
   external_components_source: github://syssi/esphome-ogt-bms@main
-  bms0_ble_name: !secret bms0_ble_name
-  bms1_ble_name: !secret bms1_ble_name
 
 esphome:
   name: ${name}
@@ -68,11 +66,11 @@ ble_client:
 ogt_bms_ble:
   - ble_client_id: client0
     id: bms0
-    ble_name: ${bms0_ble_name}
+    ble_name: !secret bms0_ble_name
     update_interval: 10s
   - ble_client_id: client1
     id: bms1
-    ble_name: ${bms1_ble_name}
+    ble_name: !secret bms1_ble_name
     update_interval: 10s
 
 binary_sensor:

--- a/esp32-ble-example-type-a.yaml
+++ b/esp32-ble-example-type-a.yaml
@@ -2,7 +2,6 @@ substitutions:
   name: ogt-bms-ble
   device_description: "Monitor a Offgridtec Battery Management System via BLE"
   external_components_source: github://syssi/esphome-ogt-bms@main
-  ble_name: !secret bms0_ble_name
 
 esphome:
   name: ${name}
@@ -57,7 +56,7 @@ ble_client:
 ogt_bms_ble:
   - ble_client_id: client0
     id: bms0
-    ble_name: ${ble_name}
+    ble_name: !secret bms0_ble_name
     update_interval: 10s
 
 binary_sensor:

--- a/esp32-ble-example-type-a.yaml
+++ b/esp32-ble-example-type-a.yaml
@@ -2,7 +2,6 @@ substitutions:
   name: ogt-bms-ble
   device_description: "Monitor a Offgridtec Battery Management System via BLE"
   external_components_source: github://syssi/esphome-ogt-bms@main
-  mac_address: !secret bms0_mac_address
   ble_name: !secret bms0_ble_name
 
 esphome:
@@ -52,7 +51,7 @@ esp32_ble_tracker:
     active: false
 
 ble_client:
-  - mac_address: ${mac_address}
+  - mac_address: !secret bms0_mac_address
     id: client0
 
 ogt_bms_ble:

--- a/esp32-ble-example-type-b.yaml
+++ b/esp32-ble-example-type-b.yaml
@@ -2,7 +2,6 @@ substitutions:
   name: ogt-bms-ble
   device_description: "Monitor a Offgridtec Battery Management System via BLE"
   external_components_source: github://syssi/esphome-ogt-bms@main
-  ble_name: !secret bms0_ble_name
 
 esphome:
   name: ${name}
@@ -57,7 +56,7 @@ ble_client:
 ogt_bms_ble:
   - ble_client_id: client0
     id: bms0
-    ble_name: ${ble_name}
+    ble_name: !secret bms0_ble_name
     update_interval: 10s
 
 binary_sensor:

--- a/esp32-ble-example-type-b.yaml
+++ b/esp32-ble-example-type-b.yaml
@@ -2,7 +2,6 @@ substitutions:
   name: ogt-bms-ble
   device_description: "Monitor a Offgridtec Battery Management System via BLE"
   external_components_source: github://syssi/esphome-ogt-bms@main
-  mac_address: !secret bms0_mac_address
   ble_name: !secret bms0_ble_name
 
 esphome:
@@ -52,7 +51,7 @@ esp32_ble_tracker:
     active: false
 
 ble_client:
-  - mac_address: ${mac_address}
+  - mac_address: !secret bms0_mac_address
     id: client0
 
 ogt_bms_ble:

--- a/test-esp32.sh
+++ b/test-esp32.sh
@@ -6,4 +6,4 @@ else
   C="components"
 fi
 
-esphome -s ble_name SmartBat-A03747 -s external_components_source $C ${1:-run} ${2:-esp32-ble-example-faker.yaml}
+esphome -s external_components_source $C ${1:-run} ${2:-esp32-ble-example-faker.yaml}

--- a/test-esp32.sh
+++ b/test-esp32.sh
@@ -6,4 +6,4 @@ else
   C="components"
 fi
 
-esphome -s ble_name SmartBat-A03747 -s mac_address B4:52:A9:09:91:42 -s external_components_source $C ${1:-run} ${2:-esp32-ble-example-faker.yaml}
+esphome -s ble_name SmartBat-A03747 -s external_components_source $C ${1:-run} ${2:-esp32-ble-example-faker.yaml}

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -2,7 +2,6 @@ substitutions:
   name: esp32c6-compatibility-test
   device_description: "Verify the project builds from source on ESP32C6"
   external_components_source: github://syssi/esphome-ogt-bms@main
-  mac_address: !secret bms0_mac_address
   ble_name: !secret bms0_ble_name
 
 esphome:
@@ -40,7 +39,7 @@ esp32_ble_tracker:
     active: false
 
 ble_client:
-  - mac_address: ${mac_address}
+  - mac_address: !secret bms0_mac_address
     id: client0
 
 ogt_bms_ble:

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -2,7 +2,6 @@ substitutions:
   name: esp32c6-compatibility-test
   device_description: "Verify the project builds from source on ESP32C6"
   external_components_source: github://syssi/esphome-ogt-bms@main
-  ble_name: !secret bms0_ble_name
 
 esphome:
   name: ${name}
@@ -45,7 +44,7 @@ ble_client:
 ogt_bms_ble:
   - ble_client_id: client0
     id: bms0
-    ble_name: ${ble_name}
+    ble_name: !secret bms0_ble_name
     update_interval: 10s
 
 binary_sensor:


### PR DESCRIPTION
## Summary

- Reference the BLE client MAC address via `!secret bms0_mac_address` directly in `ble_client:` instead of routing through a YAML substitution
- Remove the now-unused substitution entries