### PR TITLE
Add online_status sensor with unavailability tracking

### DIFF
--- a/components/ogt_bms_ble/binary_sensor.py
+++ b/components/ogt_bms_ble/binary_sensor.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
-from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC
+from esphome.const import DEVICE_CLASS_CONNECTIVITY, ENTITY_CATEGORY_DIAGNOSTIC
 
 from . import OGT_BMS_BLE_COMPONENT_SCHEMA
 
@@ -11,9 +11,14 @@ CODEOWNERS = ["@syssi"]
 
 CONF_CHARGING = "charging"
 CONF_DISCHARGING = "discharging"
+CONF_ONLINE_STATUS = "online_status"
 
 # key: binary_sensor_schema kwargs
 BINARY_SENSOR_DEFS = {
+    CONF_ONLINE_STATUS: {
+        "device_class": DEVICE_CLASS_CONNECTIVITY,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
     CONF_CHARGING: {
         "icon": "mdi:battery-charging",
         "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,

--- a/components/ogt_bms_ble/ogt_bms_ble.cpp
+++ b/components/ogt_bms_ble/ogt_bms_ble.cpp
@@ -137,38 +137,6 @@ void OgtBmsBle::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t ga
     case ESP_GATTC_DISCONNECT_EVT: {
       this->node_state = espbt::ClientState::IDLE;
 
-      this->publish_state_(this->state_of_charge_sensor_, NAN);
-      this->publish_state_(this->capacity_remaining_sensor_, NAN);
-      this->publish_state_(this->design_capacity_sensor_, NAN);
-      this->publish_state_(this->full_charge_capacity_sensor_, NAN);
-      this->publish_state_(this->total_voltage_sensor_, NAN);
-      this->publish_state_(this->mosfet_temperature_sensor_, NAN);
-      this->publish_state_(this->current_sensor_, NAN);
-      this->publish_state_(this->charging_binary_sensor_, NAN);
-      this->publish_state_(this->discharging_binary_sensor_, NAN);
-      this->publish_state_(this->power_sensor_, NAN);
-      this->publish_state_(this->charging_power_sensor_, NAN);
-      this->publish_state_(this->discharging_power_sensor_, NAN);
-      this->publish_state_(this->time_to_empty_sensor_, NAN);
-      this->publish_state_(this->time_to_empty_formatted_text_sensor_, "");
-      this->publish_state_(this->time_to_full_sensor_, NAN);
-      this->publish_state_(this->time_to_full_formatted_text_sensor_, "");
-      this->publish_state_(this->charging_cycles_sensor_, NAN);
-
-      this->publish_state_(this->min_cell_voltage_sensor_, NAN);
-      this->publish_state_(this->max_cell_voltage_sensor_, NAN);
-      this->publish_state_(this->min_voltage_cell_sensor_, NAN);
-      this->publish_state_(this->max_voltage_cell_sensor_, NAN);
-      this->publish_state_(this->average_cell_voltage_sensor_, NAN);
-      this->publish_state_(this->delta_cell_voltage_sensor_, NAN);
-      for (auto &cell : this->cells_) {
-        this->publish_state_(cell.cell_voltage_sensor_, NAN);
-      }
-
-      // There is no need to reset these values
-      // this->publish_state_(this->manufacture_date_text_sensor_, "");
-      // this->publish_state_(this->serial_number_text_sensor_, "");
-
       if (this->char_notify_handle_ != 0) {
         auto status = esp_ble_gattc_unregister_for_notify(this->parent()->get_gattc_if(),
                                                           this->parent()->get_remote_bda(), this->char_notify_handle_);

--- a/components/ogt_bms_ble/ogt_bms_ble.cpp
+++ b/components/ogt_bms_ble/ogt_bms_ble.cpp
@@ -12,6 +12,7 @@
 namespace esphome::ogt_bms_ble {
 
 static const char *const TAG = "ogt_bms_ble";
+static const uint8_t MAX_NO_RESPONSE_COUNT = 10;
 
 static std::string format_serial_number(uint16_t serial) {
   char buf[8];
@@ -247,6 +248,7 @@ void OgtBmsBle::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t ga
 }
 
 void OgtBmsBle::update() {
+  this->track_online_status_();
   if (this->node_state != espbt::ClientState::ESTABLISHED) {
     ESP_LOGW(TAG, "[%s] Not connected", ADDR_STR(this->parent_->address_str()));
     return;
@@ -358,6 +360,8 @@ void OgtBmsBle::on_ogt_bms_ble_data(const std::vector<uint8_t> &encrypted_data) 
     ESP_LOGW(TAG, "No data extracted from response. Decrypted: %s", decrypted.c_str());
     return;
   }
+
+  this->reset_online_status_tracker_();
 
   auto ogt_get_16bit = [&](size_t i) -> uint16_t {
     return (uint16_t(data[i + 1]) << 8) | (uint16_t(data[i + 0]) << 0);
@@ -545,6 +549,7 @@ void OgtBmsBle::dump_config() {  // NOLINT(google-readability-function-size,read
   ESP_LOGCONFIG(TAG, "  Device type: %c", this->device_type_);
   ESP_LOGCONFIG(TAG, "  Encryption key: %d", this->encryption_key_);
 
+  LOG_BINARY_SENSOR("", "Online Status", this->online_status_binary_sensor_);
   LOG_BINARY_SENSOR("", "Charging", this->charging_binary_sensor_);
   LOG_BINARY_SENSOR("", "Discharging", this->discharging_binary_sensor_);
 
@@ -591,6 +596,49 @@ void OgtBmsBle::dump_config() {  // NOLINT(google-readability-function-size,read
   LOG_TEXT_SENSOR("", "Time to full", this->time_to_full_formatted_text_sensor_);
   LOG_TEXT_SENSOR("", "Manufacture date", this->manufacture_date_text_sensor_);
   LOG_TEXT_SENSOR("", "Serial number", this->serial_number_text_sensor_);
+}
+
+void OgtBmsBle::track_online_status_() {
+  if (this->no_response_count_ < MAX_NO_RESPONSE_COUNT)
+    this->no_response_count_++;
+  if (this->no_response_count_ == MAX_NO_RESPONSE_COUNT) {
+    this->publish_device_unavailable_();
+    this->no_response_count_++;
+  }
+}
+
+void OgtBmsBle::reset_online_status_tracker_() {
+  this->no_response_count_ = 0;
+  this->publish_state_(this->online_status_binary_sensor_, true);
+}
+
+void OgtBmsBle::publish_device_unavailable_() {
+  this->publish_state_(this->online_status_binary_sensor_, false);
+  this->publish_state_(this->total_voltage_sensor_, NAN);
+  this->publish_state_(this->current_sensor_, NAN);
+  this->publish_state_(this->power_sensor_, NAN);
+  this->publish_state_(this->charging_power_sensor_, NAN);
+  this->publish_state_(this->discharging_power_sensor_, NAN);
+  this->publish_state_(this->error_bitmask_sensor_, NAN);
+  this->publish_state_(this->state_of_charge_sensor_, NAN);
+  this->publish_state_(this->charging_cycles_sensor_, NAN);
+  this->publish_state_(this->mosfet_temperature_sensor_, NAN);
+  this->publish_state_(this->time_to_empty_sensor_, NAN);
+  this->publish_state_(this->time_to_full_sensor_, NAN);
+  this->publish_state_(this->capacity_remaining_sensor_, NAN);
+  this->publish_state_(this->design_capacity_sensor_, NAN);
+  this->publish_state_(this->full_charge_capacity_sensor_, NAN);
+  this->publish_state_(this->min_cell_voltage_sensor_, NAN);
+  this->publish_state_(this->max_cell_voltage_sensor_, NAN);
+  this->publish_state_(this->min_voltage_cell_sensor_, NAN);
+  this->publish_state_(this->max_voltage_cell_sensor_, NAN);
+  this->publish_state_(this->delta_cell_voltage_sensor_, NAN);
+  this->publish_state_(this->average_cell_voltage_sensor_, NAN);
+  for (auto &cell : this->cells_)
+    this->publish_state_(cell.cell_voltage_sensor_, NAN);
+  this->publish_state_(this->errors_text_sensor_, "Offline");
+  this->publish_state_(this->time_to_empty_formatted_text_sensor_, "Offline");
+  this->publish_state_(this->time_to_full_formatted_text_sensor_, "Offline");
 }
 
 void OgtBmsBle::publish_state_(binary_sensor::BinarySensor *binary_sensor, const bool &state) {

--- a/components/ogt_bms_ble/ogt_bms_ble.h
+++ b/components/ogt_bms_ble/ogt_bms_ble.h
@@ -28,6 +28,9 @@ class OgtBmsBle :
   void update() override;
   float get_setup_priority() const override { return setup_priority::DATA; }
 
+  void set_online_status_binary_sensor(binary_sensor::BinarySensor *online_status_binary_sensor) {
+    online_status_binary_sensor_ = online_status_binary_sensor;
+  }
   void set_charging_binary_sensor(binary_sensor::BinarySensor *charging_binary_sensor) {
     charging_binary_sensor_ = charging_binary_sensor;
   }
@@ -107,6 +110,7 @@ class OgtBmsBle :
   void set_device_type(uint8_t device_type) { this->device_type_ = device_type; }
 
  protected:
+  binary_sensor::BinarySensor *online_status_binary_sensor_{nullptr};
   binary_sensor::BinarySensor *charging_binary_sensor_{nullptr};
   binary_sensor::BinarySensor *discharging_binary_sensor_{nullptr};
 
@@ -142,6 +146,7 @@ class OgtBmsBle :
     sensor::Sensor *cell_voltage_sensor_{nullptr};
   } cells_[16];
 
+  uint8_t no_response_count_{0};
   uint16_t char_notify_handle_{0};
   uint16_t char_command_handle_{0};
   uint8_t next_command_{7};
@@ -150,6 +155,9 @@ class OgtBmsBle :
 
   std::string decrypt_response_(const std::vector<uint8_t> &data);
   std::vector<uint8_t> extract_hex_values_(const std::string &msg);
+  void publish_device_unavailable_();
+  void reset_online_status_tracker_();
+  void track_online_status_();
   void publish_state_(binary_sensor::BinarySensor *binary_sensor, const bool &state);
   void publish_state_(sensor::Sensor *sensor, float value);
   void publish_state_(text_sensor::TextSensor *text_sensor, const std::string &state);

--- a/esp32-ble-example-multiple-devices.yaml
+++ b/esp32-ble-example-multiple-devices.yaml
@@ -76,6 +76,9 @@ ogt_bms_ble:
 binary_sensor:
   - platform: ogt_bms_ble
     ogt_bms_ble_id: bms0
+    online_status:
+      name: "online status"
+      device_id: device0
     charging:
       name: "charging"
       device_id: device0
@@ -85,6 +88,9 @@ binary_sensor:
 
   - platform: ogt_bms_ble
     ogt_bms_ble_id: bms1
+    online_status:
+      name: "online status"
+      device_id: device1
     charging:
       name: "charging"
       device_id: device1

--- a/esp32-ble-example-type-a.yaml
+++ b/esp32-ble-example-type-a.yaml
@@ -62,6 +62,8 @@ ogt_bms_ble:
 binary_sensor:
   - platform: ogt_bms_ble
     ogt_bms_ble_id: bms0
+    online_status:
+      name: "online status"
     charging:
       name: "charging"
     discharging:

--- a/esp32-ble-example-type-b.yaml
+++ b/esp32-ble-example-type-b.yaml
@@ -62,6 +62,8 @@ ogt_bms_ble:
 binary_sensor:
   - platform: ogt_bms_ble
     ogt_bms_ble_id: bms0
+    online_status:
+      name: "online status"
     charging:
       name: "charging"
     discharging:

--- a/tests/components/ogt_bms_ble/common.h
+++ b/tests/components/ogt_bms_ble/common.h
@@ -8,6 +8,10 @@ namespace esphome::ogt_bms_ble::testing {
 class TestableOgtBmsBle : public OgtBmsBle {
  public:
   using OgtBmsBle::on_ogt_bms_ble_data;
+  using OgtBmsBle::track_online_status_;
+  using OgtBmsBle::reset_online_status_tracker_;
+  using OgtBmsBle::publish_device_unavailable_;
+  uint8_t get_no_response_count() const { return no_response_count_; }
 };
 
 }  // namespace esphome::ogt_bms_ble::testing

--- a/tests/components/ogt_bms_ble/ogt_bms_ble_test.cpp
+++ b/tests/components/ogt_bms_ble/ogt_bms_ble_test.cpp
@@ -1,2 +1,177 @@
-// Type A tests: ogt_bms_ble_type_a_test.cpp
-// Type B tests: ogt_bms_ble_type_b_test.cpp
+#include <gtest/gtest.h>
+#include "common.h"
+#include "common_type_a.h"
+
+namespace esphome::ogt_bms_ble::testing {
+
+// ── Online status tracker ─────────────────────────────────────────────────────
+
+TEST(OgtBmsBleOnlineStatusTrackerTest, ReachesThreshold) {
+  TestableOgtBmsBle bms;
+  binary_sensor::BinarySensor online_status;
+  bms.set_online_status_binary_sensor(&online_status);
+
+  for (int i = 0; i < 10; i++)
+    bms.track_online_status_();
+
+  EXPECT_FALSE(online_status.state);
+}
+
+TEST(OgtBmsBleOnlineStatusTrackerTest, DoesNotRepeatAfterThreshold) {
+  TestableOgtBmsBle bms;
+  binary_sensor::BinarySensor online_status;
+  bms.set_online_status_binary_sensor(&online_status);
+
+  for (int i = 0; i < 10; i++)
+    bms.track_online_status_();
+  EXPECT_EQ(bms.get_no_response_count(), 11);
+
+  bms.track_online_status_();
+  EXPECT_EQ(bms.get_no_response_count(), 11);
+}
+
+TEST(OgtBmsBleOnlineStatusTrackerTest, ResetRestoresOnlineStatus) {
+  TestableOgtBmsBle bms;
+  binary_sensor::BinarySensor online_status;
+  bms.set_online_status_binary_sensor(&online_status);
+
+  for (int i = 0; i < 10; i++)
+    bms.track_online_status_();
+  EXPECT_FALSE(online_status.state);
+
+  bms.reset_online_status_tracker_();
+  EXPECT_TRUE(online_status.state);
+  EXPECT_EQ(bms.get_no_response_count(), 0);
+}
+
+TEST(OgtBmsBleOnlineStatusTrackerTest, CanRetriggerAfterReset) {
+  TestableOgtBmsBle bms;
+  binary_sensor::BinarySensor online_status;
+  bms.set_online_status_binary_sensor(&online_status);
+
+  for (int i = 0; i < 10; i++)
+    bms.track_online_status_();
+  bms.reset_online_status_tracker_();
+
+  for (int i = 0; i < 10; i++)
+    bms.track_online_status_();
+  EXPECT_FALSE(online_status.state);
+}
+
+TEST(OgtBmsBleOnlineStatusTrackerTest, ValidFrameResetsCounter) {
+  TestableOgtBmsBle bms;
+  bms.set_encryption_key(TYPE_A_ENCRYPTION_KEY);
+  bms.set_device_type('A');
+
+  for (int i = 0; i < 5; i++)
+    bms.track_online_status_();
+  EXPECT_EQ(bms.get_no_response_count(), 5);
+
+  bms.on_ogt_bms_ble_data(TYPE_A_SOC_70);
+  EXPECT_EQ(bms.get_no_response_count(), 0);
+}
+
+TEST(OgtBmsBleOnlineStatusTrackerTest, NotYetAtThresholdStaysOnline) {
+  TestableOgtBmsBle bms;
+  binary_sensor::BinarySensor online_status;
+  bms.set_online_status_binary_sensor(&online_status);
+
+  online_status.publish_state(true);
+  for (int i = 0; i < 9; i++)
+    bms.track_online_status_();
+
+  EXPECT_TRUE(online_status.state);
+}
+
+// ── publish_device_unavailable_ ───────────────────────────────────────────────
+
+TEST(OgtBmsBlePublishDeviceUnavailableTest, SetsOnlineStatusFalse) {
+  TestableOgtBmsBle bms;
+  binary_sensor::BinarySensor online_status;
+  bms.set_online_status_binary_sensor(&online_status);
+
+  online_status.publish_state(true);
+  bms.publish_device_unavailable_();
+
+  EXPECT_FALSE(online_status.state);
+}
+
+TEST(OgtBmsBlePublishDeviceUnavailableTest, SetsNumericSensorsToNAN) {
+  TestableOgtBmsBle bms;
+  sensor::Sensor total_voltage, current, power, charging_power, discharging_power;
+  sensor::Sensor error_bitmask, state_of_charge, charging_cycles;
+  sensor::Sensor capacity_remaining, design_capacity, full_charge_capacity;
+  bms.set_total_voltage_sensor(&total_voltage);
+  bms.set_current_sensor(&current);
+  bms.set_power_sensor(&power);
+  bms.set_charging_power_sensor(&charging_power);
+  bms.set_discharging_power_sensor(&discharging_power);
+  bms.set_error_bitmask_sensor(&error_bitmask);
+  bms.set_state_of_charge_sensor(&state_of_charge);
+  bms.set_charging_cycles_sensor(&charging_cycles);
+  bms.set_capacity_remaining_sensor(&capacity_remaining);
+  bms.set_design_capacity_sensor(&design_capacity);
+  bms.set_full_charge_capacity_sensor(&full_charge_capacity);
+
+  bms.publish_device_unavailable_();
+
+  EXPECT_TRUE(std::isnan(total_voltage.state));
+  EXPECT_TRUE(std::isnan(current.state));
+  EXPECT_TRUE(std::isnan(power.state));
+  EXPECT_TRUE(std::isnan(charging_power.state));
+  EXPECT_TRUE(std::isnan(discharging_power.state));
+  EXPECT_TRUE(std::isnan(error_bitmask.state));
+  EXPECT_TRUE(std::isnan(state_of_charge.state));
+  EXPECT_TRUE(std::isnan(charging_cycles.state));
+  EXPECT_TRUE(std::isnan(capacity_remaining.state));
+  EXPECT_TRUE(std::isnan(design_capacity.state));
+  EXPECT_TRUE(std::isnan(full_charge_capacity.state));
+}
+
+TEST(OgtBmsBlePublishDeviceUnavailableTest, SetsCellSensorsToNAN) {
+  TestableOgtBmsBle bms;
+  sensor::Sensor cell0, cell1;
+  bms.set_cell_voltage_sensor(0, &cell0);
+  bms.set_cell_voltage_sensor(1, &cell1);
+
+  bms.publish_device_unavailable_();
+
+  EXPECT_TRUE(std::isnan(cell0.state));
+  EXPECT_TRUE(std::isnan(cell1.state));
+}
+
+TEST(OgtBmsBlePublishDeviceUnavailableTest, SetsDynamicTextSensorsToOffline) {
+  TestableOgtBmsBle bms;
+  text_sensor::TextSensor errors, time_to_empty_formatted, time_to_full_formatted;
+  bms.set_errors_text_sensor(&errors);
+  bms.set_time_to_empty_formatted_text_sensor(&time_to_empty_formatted);
+  bms.set_time_to_full_formatted_text_sensor(&time_to_full_formatted);
+
+  bms.publish_device_unavailable_();
+
+  EXPECT_EQ(errors.state, "Offline");
+  EXPECT_EQ(time_to_empty_formatted.state, "Offline");
+  EXPECT_EQ(time_to_full_formatted.state, "Offline");
+}
+
+TEST(OgtBmsBlePublishDeviceUnavailableTest, LeavesStaticTextSensorsUnchanged) {
+  TestableOgtBmsBle bms;
+  text_sensor::TextSensor manufacture_date, serial_number;
+  manufacture_date.publish_state("2020.03.17");
+  serial_number.publish_state("03747");
+  bms.set_manufacture_date_text_sensor(&manufacture_date);
+  bms.set_serial_number_text_sensor(&serial_number);
+
+  bms.publish_device_unavailable_();
+
+  EXPECT_EQ(manufacture_date.state, "2020.03.17");
+  EXPECT_EQ(serial_number.state, "03747");
+}
+
+TEST(OgtBmsBlePublishDeviceUnavailableTest, NullSensorsDoNotCrash) {
+  TestableOgtBmsBle bms;
+
+  EXPECT_NO_FATAL_FAILURE(bms.publish_device_unavailable_());
+}
+
+}  // namespace esphome::ogt_bms_ble::testing

--- a/tests/test_component_schemas.py
+++ b/tests/test_component_schemas.py
@@ -46,9 +46,10 @@ class TestSensorLists:
 
 class TestBinarySensorConstants:
     def test_binary_sensor_defs_dict(self):
+        assert binary_sensor.CONF_ONLINE_STATUS in binary_sensor.BINARY_SENSOR_DEFS
         assert binary_sensor.CONF_CHARGING in binary_sensor.BINARY_SENSOR_DEFS
         assert binary_sensor.CONF_DISCHARGING in binary_sensor.BINARY_SENSOR_DEFS
-        assert len(binary_sensor.BINARY_SENSOR_DEFS) == 2
+        assert len(binary_sensor.BINARY_SENSOR_DEFS) == 3
 
 
 class TestTextSensorConstants:


### PR DESCRIPTION
## Summary

- Adds `online_status` binary sensor (`device_class: connectivity`, `entity_category: diagnostic`)
- After 10 consecutive `update()` cycles without a valid BMS frame, marks the device unavailable: `online_status` → false, all numeric sensors → NaN, dynamic text sensors (`errors`, `time_to_empty_formatted`, `time_to_full_formatted`) → "Offline"
- Static identity sensors (`manufacture_date`, `serial_number`) are left unchanged
- Integrates `track_online_status_()` at the start of `update()` and `reset_online_status_tracker_()` in `on_ogt_bms_ble_data()` after decryption and data extraction succeed

## Test plan

- [x] C++ unit tests: `OgtBmsBleOnlineStatusTrackerTest` (6 tests) and `OgtBmsBlePublishDeviceUnavailableTest` (6 tests) — all 42 tests pass
- [x] pytest schema validation passes (3 binary sensor defs)
- [x] `esp32-ble-example-type-a.yaml`, `esp32-ble-example-type-b.yaml`, and `esp32-ble-example-multiple-devices.yaml` updated with `online_status` sensor